### PR TITLE
Progress indicators, concurrency improvements

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,16 @@
         <listener class="intellij.pc.fileWatcher.PcFileOpenedListener" topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
     </projectListeners>
 
+    <actions>
+        <action
+                id="intellij.pc.ReindexWorkspace"
+                class="intellij.pc.actions.IndexWorkspaceAction"
+                text="Reindex Workspace"
+                description="SDK action example 2">
+            <add-to-group group-id="ToolsMenu" anchor="first"/>
+        </action>
+    </actions>
+
     <extensions defaultExtensionNs="com.intellij">
         <projectService id="PresentationCompilerPluginService"
                 serviceImplementation="intellij.pc.PresentationCompilerPluginService"/>

--- a/src/main/scala/intellij/pc/Embedded.scala
+++ b/src/main/scala/intellij/pc/Embedded.scala
@@ -1,11 +1,7 @@
 package intellij.pc
 
 import com.intellij.openapi.diagnostic.Logger
-import coursierapi.Dependency
-import coursierapi.Fetch
-import coursierapi.MavenRepository
-import coursierapi.Repository
-import coursierapi.ResolutionParams
+import coursierapi._
 
 import java.net.URLClassLoader
 import java.nio.file.Path

--- a/src/main/scala/intellij/pc/ReflectionUnregisterUtil.scala
+++ b/src/main/scala/intellij/pc/ReflectionUnregisterUtil.scala
@@ -2,12 +2,10 @@ package intellij.pc
 
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.extensions.ExtensionPoint
-import com.intellij.openapi.extensions.Extensions
+import com.intellij.openapi.extensions.{ExtensionPoint, Extensions}
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.intellij.util.KeyedLazyInstance
-import intellij.pc.symbolSearch.Indexer
 import kotlin.coroutines.Continuation
 
 import scala.util.control.NonFatal
@@ -37,7 +35,6 @@ class ReflectionUnregisterUtil extends ProjectActivity {
           e
         )
     }
-    project.getService(classOf[Indexer]).index()
     project
   }
 }

--- a/src/main/scala/intellij/pc/actions/IndexWorkspaceAction.scala
+++ b/src/main/scala/intellij/pc/actions/IndexWorkspaceAction.scala
@@ -1,0 +1,30 @@
+package intellij.pc.actions
+
+import com.intellij.openapi.actionSystem.{ActionUpdateThread, AnAction, AnActionEvent}
+import com.intellij.openapi.diagnostic.Logger
+import intellij.pc.symbolSearch.IndexProcess
+
+final class IndexWorkspaceAction extends AnAction("Reindex Workspace") {
+  private def indexProcess    = IndexProcess.getInstance
+  final private val logger = Logger.getInstance(classOf[IndexWorkspaceAction])
+
+  override def actionPerformed(event: AnActionEvent): Unit = {
+    try {
+      val project   = event.getProject
+      val workspace = project.getBasePath
+      if (!indexProcess.isReindexingWorkspace.get()) indexProcess.startWorkspaceIndexing(project)
+      logger.debug(s"Workspace reindex started: $workspace")
+    } catch {
+      case e => logger.error("Error occurred during workspace indexing", e)
+    }
+  }
+
+  override def getActionUpdateThread: ActionUpdateThread = ActionUpdateThread.BGT
+
+  override def update(event: AnActionEvent): Unit = {
+    event
+      .getPresentation
+      .setEnabled(!indexProcess.isReindexingWorkspace.get())
+  }
+
+}

--- a/src/main/scala/intellij/pc/fileWatcher/ClasspathListener.scala
+++ b/src/main/scala/intellij/pc/fileWatcher/ClasspathListener.scala
@@ -1,8 +1,7 @@
 package intellij.pc.fileWatcher
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ModuleRootEvent
-import com.intellij.openapi.roots.ModuleRootListener
+import com.intellij.openapi.roots.{ModuleRootEvent, ModuleRootListener}
 import intellij.pc.PresentationCompilerPluginService
 
 final class ClasspathListener(project: Project) extends ModuleRootListener {

--- a/src/main/scala/intellij/pc/fileWatcher/FileStateService.scala
+++ b/src/main/scala/intellij/pc/fileWatcher/FileStateService.scala
@@ -22,7 +22,7 @@ class FileStateService(project: Project) {
     if (modules.nonEmpty) {
       project
         .getService(classOf[PresentationCompilerPluginService])
-        .restarPc(modules)
+        .restartPc(modules)
     }
   }
 

--- a/src/main/scala/intellij/pc/fileWatcher/PcFileListener.scala
+++ b/src/main/scala/intellij/pc/fileWatcher/PcFileListener.scala
@@ -5,10 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.BulkFileListener
-import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent
-import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent
-import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent
-import com.intellij.openapi.vfs.newvfs.events.VFileEvent
+import com.intellij.openapi.vfs.newvfs.events.{VFileContentChangeEvent, VFileCreateEvent, VFileDeleteEvent, VFileEvent}
 import com.intellij.util.concurrency.AppExecutorUtil
 import intellij.pc.PresentationCompilerPluginService
 import intellij.pc.symbolSearch.Indexer
@@ -39,7 +36,7 @@ final class PcFileListener(project: Project) extends BulkFileListener {
     if (modules.nonEmpty)
       project
         .getService(classOf[PresentationCompilerPluginService])
-        .restarPc(modules)
+        .restartPc(modules)
     if (changedFiles.nonEmpty)
       ReadAction
         .nonBlocking[Unit] { () =>

--- a/src/main/scala/intellij/pc/fileWatcher/PcFileOpenedListener.scala
+++ b/src/main/scala/intellij/pc/fileWatcher/PcFileOpenedListener.scala
@@ -1,8 +1,7 @@
 package intellij.pc.fileWatcher
 
 import com.intellij.openapi.application.ReadAction
-import com.intellij.openapi.fileEditor.FileEditorManagerEvent
-import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.fileEditor.{FileEditorManagerEvent, FileEditorManagerListener}
 import com.intellij.openapi.project.Project
 import com.intellij.util.concurrency.AppExecutorUtil
 

--- a/src/main/scala/intellij/pc/symbolSearch/IndexProcess.scala
+++ b/src/main/scala/intellij/pc/symbolSearch/IndexProcess.scala
@@ -1,0 +1,35 @@
+package intellij.pc.symbolSearch
+
+import com.intellij.openapi.progress.Task.Backgroundable
+import com.intellij.openapi.progress.{ProgressIndicator, ProgressManager}
+import com.intellij.openapi.project.Project
+import intellij.pc.util.PerformanceUtils
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+final class IndexProcess {
+  val isReindexingWorkspace: AtomicBoolean = new AtomicBoolean(false)
+
+  def startWorkspaceIndexing(project: Project): Unit = if (!isReindexingWorkspace.get()) {
+    isReindexingWorkspace.set(true)
+
+    ProgressManager
+      .getInstance
+      .run(new Backgroundable(project, "Indexing workspace...", true) {
+        override def run(indicator: ProgressIndicator): Unit = {
+          PerformanceUtils.timed("Workspace indexing") {
+            val indexingIndicator = IndexingProgressIndicator(indicator)
+            try {
+              project.getService(classOf[Indexer]).indexWorkspace(indexingIndicator)
+            } finally {
+              isReindexingWorkspace.set(false)
+            }
+          }
+        }
+      }.setCancelText("Stop Workspace Indexation"))
+  }
+}
+
+object IndexProcess {
+  lazy val getInstance: IndexProcess = new IndexProcess
+}

--- a/src/main/scala/intellij/pc/symbolSearch/IndexingProgressIndicator.scala
+++ b/src/main/scala/intellij/pc/symbolSearch/IndexingProgressIndicator.scala
@@ -1,0 +1,58 @@
+package intellij.pc.symbolSearch
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.ProgressIndicator
+
+trait ProgressIndicatorWrapper {
+  def step(procesedEntry: String): Unit
+  def nextProgress(name: String, totalSize: Option[Int]): Unit
+  def isCancelled: Boolean
+}
+
+object ProgressIndicatorWrapper {
+  def empty: ProgressIndicatorWrapper = new ProgressIndicatorWrapper {
+    override def step(procesedEntry: String): Unit = ()
+    override def nextProgress(name: String, totalSize: Option[Int]): Unit = ()
+    override def isCancelled: Boolean = false
+  }
+}
+
+case class IndexingProgressIndicator(progressIndicator: ProgressIndicator) extends ProgressIndicatorWrapper {
+  final private val logger = Logger.getInstance(classOf[IndexingProgressIndicator])
+
+  progressIndicator.setIndeterminate(false)
+
+  private var progressName = ""
+  private var allFiles: Option[Int] = None
+  private var processed = 0
+
+  def isCancelled: Boolean = progressIndicator.isCanceled
+
+  /**
+   * Increments the count if present, updates [[text2]]
+   */
+  def step(processedEntry: String): Unit =
+    allFiles match {
+      case Some(allFiles) =>
+        processed += 1
+        progressIndicator.setText(s"$progressName [$processed / $allFiles]")
+        progressIndicator.setText2(processedEntry)
+        progressIndicator.setFraction(processed.toDouble / allFiles.toDouble)
+      case None =>
+        logger.warn("Trying to step on progress bar without known size.")
+    }
+
+  def nextProgress(name: String, totalSize: Option[Int]): Unit = {
+    allFiles = totalSize
+    progressName = name
+    // reset
+    progressIndicator.setIndeterminate(totalSize.isEmpty)
+    progressIndicator.setFraction(0d)
+    progressIndicator.setText2("")
+
+    // start next progress
+    progressIndicator.setText(progressName)
+  }
+
+
+}

--- a/src/main/scala/intellij/pc/symbolSearch/LazyClasspathSearch.scala
+++ b/src/main/scala/intellij/pc/symbolSearch/LazyClasspathSearch.scala
@@ -1,0 +1,78 @@
+package intellij.pc.symbolSearch
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.progress.Task.Backgroundable
+import com.intellij.openapi.progress.{ProgressIndicator, ProgressManager}
+import com.intellij.openapi.project.Project
+import com.jetbrains.rd.util.AtomicReference
+import intellij.pc.util.PerformanceUtils
+
+import java.nio.file.Path
+import scala.meta.internal.metals.{ClasspathSearch, CompressedPackageIndex, ExcludedPackagesHandler, PackageIndex}
+
+final class LazyClasspathSearch(project: Project, classpath: Seq[Path]) {
+  private val logger = Logger.getInstance(getClass.getName)
+  private val search: AtomicReference[ClasspathSearch] = new AtomicReference[ClasspathSearch](ClasspathSearch.empty)
+
+  def getSearch: ClasspathSearch = search.get()
+
+  private def watchingClasspathSearch(indicator: ProgressIndicatorWrapper): ClasspathSearch.Indexer = {
+      (classpath, excludePackages, bucketSize) => {
+        indicator.nextProgress("Indexing classpath", Some(classpath.size))
+        val packages = WatchedPackageIndex.fromClasspath(
+          classpath,
+          excludePackages.isExcludedPackage,
+          indicator
+        )
+
+        indicator.nextProgress("Compressing classpath", None)
+        val map = CompressedPackageIndex.fromPackages(
+          packages,
+          excludePackages.isExcludedPackage,
+          bucketSize
+        )
+        new ClasspathSearch(map)
+      }
+  }
+
+  ProgressManager
+    .getInstance
+    .run(new Backgroundable(project, "Indexing classpath...", true) {
+      override def run(indicator: ProgressIndicator): Unit = {
+        PerformanceUtils.timed("Classpath indexing") {
+          try {
+            val indexingProgress = IndexingProgressIndicator(indicator)
+            logger.warn("Starting classpath indexation")
+            val indexedSearch = watchingClasspathSearch(indexingProgress).index(classpath, ExcludedPackagesHandler.default)
+            search.getAndSet(indexedSearch)
+          } finally {
+            indicator.setIndeterminate(false)
+          }
+        }
+      }
+    }.setCancelText("Stop Classpath Indexation"))
+}
+
+private class WatchedPackageIndex(indicator: ProgressIndicatorWrapper) extends PackageIndex {
+
+  override def visit(entry: Path): Unit =
+    if (!indicator.isCancelled) {
+      indicator.step(entry.toString)
+      super.visit(entry)
+    }
+}
+
+object WatchedPackageIndex {
+  def fromClasspath(
+                     classpath: collection.Seq[Path],
+                     isExcludedPackage: String => Boolean,
+                     progressIndicator: ProgressIndicatorWrapper,
+                   ): PackageIndex = {
+    val packages = new WatchedPackageIndex(progressIndicator)
+    packages.visitBootClasspath(isExcludedPackage)
+    classpath.foreach { path => packages.visit(path) }
+    packages
+  }
+}
+
+

--- a/src/main/scala/intellij/pc/symbolSearch/MetalsSymbolSearch.scala
+++ b/src/main/scala/intellij/pc/symbolSearch/MetalsSymbolSearch.scala
@@ -1,19 +1,14 @@
 package intellij.pc.symbolSearch
 
-import com.intellij.openapi.module.Module
-import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.module.{Module, ModuleManager}
 import com.intellij.openapi.project.Project
 import org.eclipse.lsp4j.Location
 
 import java.net.URI
-import java.util.Collections
-import java.util.Optional
+import java.util.{Collections, Optional}
 import java.{util => ju}
 import scala.meta.internal.metals.WorkspaceSymbolQuery
-import scala.meta.pc.ParentSymbols
-import scala.meta.pc.SymbolDocumentation
-import scala.meta.pc.SymbolSearch
-import scala.meta.pc.SymbolSearchVisitor
+import scala.meta.pc.{ParentSymbols, SymbolDocumentation, SymbolSearch, SymbolSearchVisitor}
 
 /** Implementation of SymbolSearch that delegates to WorkspaceSymbolProvider and
   * SymbolDocumentationIndexer.

--- a/src/main/scala/intellij/pc/symbolSearch/WorkspaceSymbolProvider.scala
+++ b/src/main/scala/intellij/pc/symbolSearch/WorkspaceSymbolProvider.scala
@@ -3,18 +3,14 @@ package intellij.pc.symbolSearch
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.OrderEnumerator
-import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.roots.{OrderEnumerator, ProjectRootManager}
 
-import java.nio.file.Files
-import java.nio.file.Path
+import java.nio.file.{Files, Path}
 import scala.collection.concurrent.TrieMap
-import scala.meta.internal.metals.Fuzzy
-import scala.meta.internal.metals.WorkspaceSymbolInformation
-import scala.meta.internal.metals.WorkspaceSymbolQuery
+import scala.meta.internal.metals.{Fuzzy, WorkspaceSymbolInformation, WorkspaceSymbolQuery}
 import scala.meta.pc.SymbolSearchVisitor
 
-class WorkspaceSymbolProvider(project: Project) {
+final class WorkspaceSymbolProvider(project: Project) {
   private val logger = Logger.getInstance(getClass.getName)
   private val MaxWorkspaceMatchesForShortQuery = 100
   private val inWorkspace: TrieMap[Path, WorkspaceSymbolsIndex] =
@@ -47,6 +43,7 @@ class WorkspaceSymbolProvider(project: Project) {
       Indexer.forAllSourceFiles(
         fileIndex,
         module,
+        ProgressIndicatorWrapper.empty,
         { source =>
           val path = source.toNioPath
           for {
@@ -80,6 +77,7 @@ class WorkspaceSymbolProvider(project: Project) {
       Indexer.forAllSourceFiles(
         fileIndex,
         module,
+        ProgressIndicatorWrapper.empty,
         { source =>
           val path = source.toNioPath
           for {

--- a/src/main/scala/intellij/pc/symbolSearch/WorkspaceSymbolsIndex.scala
+++ b/src/main/scala/intellij/pc/symbolSearch/WorkspaceSymbolsIndex.scala
@@ -1,7 +1,6 @@
 package intellij.pc.symbolSearch
 
-import scala.meta.internal.metals.StringBloomFilter
-import scala.meta.internal.metals.WorkspaceSymbolInformation
+import scala.meta.internal.metals.{StringBloomFilter, WorkspaceSymbolInformation}
 
 /** An index of symbols defined in workspace sources.
   *

--- a/src/main/scala/intellij/pc/util/PerformanceUtils.scala
+++ b/src/main/scala/intellij/pc/util/PerformanceUtils.scala
@@ -1,0 +1,19 @@
+package intellij.pc.util
+
+import com.intellij.openapi.diagnostic.Logger
+
+import java.time.{Duration, Instant}
+
+object PerformanceUtils {
+  private val logger = Logger.getInstance(getClass.getName)
+
+  def timed[T](text: String)(fn: => T): T = {
+    val start = Instant.now()
+    val res = fn
+    val end = Instant.now()
+    val duration = Duration.between(start, end)
+    logger.warn(s"$text took $duration to complete.")
+    res
+  }
+
+}


### PR DESCRIPTION
I've removed workspace indexation, to not be run automatically on startup. It is now possible to do in `Tools -> Reindex Workspace`

On top of that, classpath search is now lazily computed.
Presentation compiler is now also async.

In plugin logs, there are warns that contain the duration of classpath + workspace indexation